### PR TITLE
auto remove dumb SD assertions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: exemplar
 Title: Generate Validation Functions to Make Sure One Object Looks Like Another
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     person(given = "David",
            family = "Neuzerling",

--- a/R/common-assertions.R
+++ b/R/common-assertions.R
@@ -75,11 +75,25 @@ generate_sd_assertions <- function(
       !enable
     )
   )
-  preface(
-    to_assert,
-    c(
-      "(Un)comment or modify the below deviance assertions if needed.",
-      glue::glue("The mean is {avg} and the standard deviation is {std_dev}:")
+  illegal <- any(c(x > (avg + std_dev * allowed_deviance),
+                   x < (avg -std_dev * allowed_deviance)), na.rm = TRUE)
+
+  sd_assertion_output <- maybe_comment_with_remark(
+    code = to_assert,
+    condition = illegal,
+    remark = glue::glue("Data is outside of mean ({avg}) +/- ({allowed_deviance} * {std_dev}),
+                        so Standard Deviation assertions have been disabled."))
+
+  if (!illegal){
+    sd_assertion_output <- preface(
+      to_assert,
+      c(
+        "(Un)comment or modify the below deviance assertions if needed.",
+        glue::glue("The mean is {avg} and the standard deviation is {std_dev}:")
+      )
     )
-  )
+  }
+
+  return(sd_assertion_output)
+
 }

--- a/tests/testthat/test-dataframe.R
+++ b/tests/testthat/test-dataframe.R
@@ -26,3 +26,14 @@ test_that("Validation test: starwars", {
   eval(parse(text = function_text))
   expect_true(validate_starwars(starwars))
 })
+
+test_that("Validation test: iris", {
+  withr::with_output_sink(
+    nullfile(),
+    function_text <- exemplar(iris,
+                              .enable_deviance_assertions = TRUE,
+                              .allowed_deviance =  2)
+  )
+  eval(parse(text = function_text))
+  expect_true(validate_iris(iris))
+})


### PR DESCRIPTION
Hi, as discussed [here](https://twitter.com/mdneuzerling/status/1506732215429853186), and the following threads, it's possible that users will specify a standard deviation expectation which is already violated. In this case, the expectation should just be commented out.

I tried to stay within your style, see if its ok.

I also added a test, but to test my functionality more thoroughly, see this example:

```
exemplar(iris[, 2:3], .enable_deviance_assertions = TRUE, .allowed_deviance = 2)
```